### PR TITLE
test: add unit tests for product and user controllers

### DIFF
--- a/controllers/test/productController.test.js
+++ b/controllers/test/productController.test.js
@@ -1,0 +1,51 @@
+// Importar el controlador de productos y el módulo fs
+const productController = require('../productController');
+const fs = require('fs');
+
+// Simular el módulo fs para evitar operaciones reales en el sistema de archivos
+jest.mock('fs');
+
+describe('productController.getProducts', () => {
+  let req, res;
+
+  // Configurar objetos req y res antes de cada prueba
+  beforeEach(() => {
+    req = {}; // Simular un objeto de solicitud vacío
+    res = {
+      json: jest.fn(), // Simular el método json de la respuesta
+      status: jest.fn().mockReturnThis() // Simular el método status de la respuesta
+    };
+  });
+
+  // Limpiar los mocks después de cada prueba
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return products as JSON on success', () => {
+    // Simular datos de productos y la respuesta del método readFileSync
+    const mockProducts = [{ id: 1, name: 'Product A' }];
+    fs.readFileSync.mockReturnValue(JSON.stringify(mockProducts));
+
+    // Llamar al controlador
+    productController.getProducts(req, res);
+
+    // Verificar que la respuesta JSON contiene los productos simulados
+    expect(res.json).toHaveBeenCalledWith(mockProducts);
+    // Verificar que no se llamó al método status
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should return 500 and error message on failure', () => {
+    // Simular un error al leer el archivo
+    const error = new Error('File not found');
+    fs.readFileSync.mockImplementation(() => { throw error; });
+
+    // Llamar al controlador
+    productController.getProducts(req, res);
+
+    // Verificar que se devolvió un código de estado 500 y el mensaje de error
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: error.message });
+  });
+});

--- a/controllers/test/productController.test.js
+++ b/controllers/test/productController.test.js
@@ -23,11 +23,9 @@ describe('productController.getProducts', () => {
   });
 
   it('should return products as JSON on success', () => {
-    // Simular datos de productos y la respuesta del método readFileSync
     const mockProducts = [{ id: 1, name: 'Product A' }];
     fs.readFileSync.mockReturnValue(JSON.stringify(mockProducts));
 
-    // Llamar al controlador
     productController.getProducts(req, res);
 
     // Verificar que la respuesta JSON contiene los productos simulados

--- a/controllers/test/userController.test.js
+++ b/controllers/test/userController.test.js
@@ -1,5 +1,5 @@
 // Importar el controlador de usuarios y el módulo fs
-const userController = require('../userController'); // Actualizar el path relativo
+const userController = require('../userController');
 const fs = require('fs');
 
 // Simular el módulo fs para evitar operaciones reales en el sistema de archivos

--- a/controllers/test/userController.test.js
+++ b/controllers/test/userController.test.js
@@ -1,0 +1,51 @@
+// Importar el controlador de usuarios y el módulo fs
+const userController = require('../userController'); // Actualizar el path relativo
+const fs = require('fs');
+
+// Simular el módulo fs para evitar operaciones reales en el sistema de archivos
+jest.mock('fs');
+
+describe('userController.getUsers', () => {
+  let req, res;
+
+  // Configurar objetos req y res antes de cada prueba
+  beforeEach(() => {
+    req = {}; // Simular un objeto de solicitud vacío
+    res = {
+      json: jest.fn(), // Simular el método json de la respuesta
+      status: jest.fn().mockReturnThis() // Simular el método status de la respuesta
+    };
+  });
+
+  // Limpiar los mocks después de cada prueba
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return users as JSON on success', () => {
+    // Simular datos de usuarios y la respuesta del método readFileSync
+    const mockUsers = [{ id: 1, name: 'Alice' }];
+    fs.readFileSync.mockReturnValue(JSON.stringify(mockUsers));
+
+    // Llamar al controlador
+    userController.getUsers(req, res);
+
+    // Verificar que la respuesta JSON contiene los usuarios simulados
+    expect(res.json).toHaveBeenCalledWith(mockUsers);
+    // Verificar que no se llamó al método status
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should return 500 and error message on failure', () => {
+    // Simular un error al leer el archivo
+    const error = new Error('File not found');
+    fs.readFileSync.mockImplementation(() => { throw error; });
+
+    // Llamar al controlador
+    userController.getUsers(req, res);
+
+    // Verificar que se devolvió un código de estado 500 y el mensaje de error
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: error.message });
+  });
+});


### PR DESCRIPTION
This pull request introduces unit tests for the `productController` and `userController` to ensure their functionality is properly validated. The tests simulate filesystem operations and cover both successful and error scenarios.

### Added unit tests for controllers:

* [`controllers/test/productController.test.js`](diffhunk://#diff-358f064454a0734e384dcd86b0a0724557c28b02dfb44a1c6c5aaa705a59fa98R1-R51): Added tests for `productController.getProducts` to verify it correctly returns product data as JSON on success and handles errors by returning a 500 status with an error message.

* [`controllers/test/userController.test.js`](diffhunk://#diff-e23d293d3f11bb12a5f7dac6e23b78fc76fa216c9628a9d21365ea437ab852f8R1-R51): Added tests for `userController.getUsers` to ensure it returns user data as JSON on success and handles errors by returning a 500 status with an error message.